### PR TITLE
Fix main table background color.

### DIFF
--- a/src/components/layout-editor/layout-editor.scss
+++ b/src/components/layout-editor/layout-editor.scss
@@ -297,6 +297,14 @@
   }
 }
 
+@mixin main-table-defaults {
+  & > gx-le-tabular-table {
+    & > gx-table {
+      min-width: fit-content;
+    }
+  }
+}
+
 gx-layout-editor {
   display: block;
   position: relative;
@@ -329,4 +337,6 @@ gx-layout-editor {
   @include default-control-render();
 
   @include controls-customization();
+
+  @include main-table-defaults();
 }


### PR DESCRIPTION
If the content of the main table exceeds the size of the container,
it does not paint the background color of the table well.
The absence of color is seen when scroll horizontally.